### PR TITLE
with hard quotes the variable is not being interpolated

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -2,7 +2,7 @@
 
 if [ -n "${push}" -a "${push}" == "true" -o "${push}" == "false" ]
 then
-    git tag -a ${tag} -m '${tag_message}'
+    git tag -a ${tag} -m "${tag_message}"
     if [ "${push}" == "true" ]; then
         git push --follow-tags
     fi


### PR DESCRIPTION
git tag message was always coming in as ${tag_message} because of the hard quotes.
